### PR TITLE
Make the slug non existant if null with setEmpty

### DIFF
--- a/docs/filter-rules.md
+++ b/docs/filter-rules.md
@@ -300,7 +300,6 @@ $result = $f->filter(['title' => 'Slug this title !']);
 // array(2) { ["title"]=> string(17) "Slug this title !" ["slug"]=> string(15) "slug-this-title" }
 ```
 
-
 ## String
 
 Make sure the value is a string.

--- a/src/FilterResource.php
+++ b/src/FilterResource.php
@@ -232,7 +232,8 @@ class FilterResource
     /**
      * Results that returns a value slugged
      *
-     * @param type $fieldToSlugFrom
+     * @param string|null $fieldToSlugFrom
+     * @return $this
      */
     public function slug($fieldToSlugFrom = null)
     {

--- a/src/FilterRule/Slug.php
+++ b/src/FilterRule/Slug.php
@@ -3,7 +3,7 @@
  * Particle.
  *
  * @link      http://github.com/particle-php for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Particle (http://particle-php.com)
+ * @copyright Copyright (c) 2005-2016 Particle (http://particle-php.com)
  * @license   https://github.com/particle-php/Filter/blob/master/LICENSE New BSD License
  */
 namespace Particle\Filter\FilterRule;

--- a/src/FilterRule/Slug.php
+++ b/src/FilterRule/Slug.php
@@ -32,7 +32,7 @@ class Slug extends FilterRule
     /**
      * @var string
      */
-    private $transliterator = "Any-Latin; Latin-ASCII; NFD; [:Nonspacing Mark:] Remove; NFC; [:Punctuation:] Remove; Lower();";
+    private $transliterator = 'Any-Latin; Latin-ASCII; NFD; [:Nonspacing Mark:] Remove; NFC; [:Punctuation:] Remove; Lower();';
 
     /**
      * @param string $fieldToSlugFrom
@@ -55,7 +55,7 @@ class Slug extends FilterRule
         }
 
         if (is_null($value)) {
-            return;
+            return $this->setEmpty();
         }
 
         $value = transliterator_transliterate($this->transliterator, $value);

--- a/tests/FilterRule/SlugTest.php
+++ b/tests/FilterRule/SlugTest.php
@@ -52,4 +52,18 @@ class SlugTest extends \PHPUnit_Framework_TestCase
             ['', 'a-ae-ubermensch-pa-hoyeste-niva-i-a-lublu-php-fi', 'test', 'A æ Übérmensch på høyeste nivå! И я люблю PHP ! ﬁ'],
         ];
     }
+
+    /**
+     * Test that a slug based of a non existing key, does not exist.
+     */
+    public function testSlugFilterEmptyIfNotAvailable()
+    {
+        $this->filter->value('slug')->slug('title');
+
+        $result = $this->filter->filter([
+            'test' => 'test',
+        ]);
+
+        $this->assertEquals(['test' => 'test'], $result);
+    }
 }


### PR DESCRIPTION
### What?

I added the solution to your problem @jhuet, with `setEmpty()` :)

### Checklist

- [x] Added unit test for added/fixed code
- [x] Updated the documentation
- [?] Scrutinizer code coverage is 100%
- [x] Scrutinizer code quality is as high as possible

### Linked issue

https://github.com/particle-php/Filter/pull/47

